### PR TITLE
Add memo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine AS build
 WORKDIR /tmp/linux-src
 RUN apk add --no-cache --update ca-certificates libc-dev linux-headers libressl-dev elfutils-dev curl gcc bison flex make musl-dev \
     && curl -fsSL https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.19.tar.gz | tar -xzf - --strip-components=1 \
-    # if something wrong happened,try to use the sentence below,instead of the one above
+    # if something wrong happened or alpine is not using kernel version:4.19.0, try to use the sentence below,instead of the one above
     # && curl -fsSL https://www.kernel.org/pub/linux/kernel/v4.x/linux-$(uname -r | cut -d '-' -f 1).tar.gz | tar -xzf - --strip-components=1 \
     && make defconfig \
     && ([ ! -f /proc/1/root/proc/config.gz ] || zcat /proc/1/root/proc/config.gz > .config) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine AS build
 WORKDIR /tmp/linux-src
 RUN apk add --no-cache --update ca-certificates libc-dev linux-headers libressl-dev elfutils-dev curl gcc bison flex make musl-dev \
     && curl -fsSL https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.19.tar.gz | tar -xzf - --strip-components=1 \
+    # if something wrong happened,try to use the sentence below,instead of the one above
+    # && curl -fsSL https://www.kernel.org/pub/linux/kernel/v4.x/linux-$(uname -r | cut -d '-' -f 1).tar.gz | tar -xzf - --strip-components=1 \
     && make defconfig \
     && ([ ! -f /proc/1/root/proc/config.gz ] || zcat /proc/1/root/proc/config.gz > .config) \
     && printf '%s\n' 'CONFIG_USBIP_CORE=m' 'CONFIG_USBIP_VHCI_HCD=m' 'CONFIG_USBIP_VHCI_HC_PORTS=8' 'CONFIG_USBIP_VHCI_NR_HCS=1' >> .config \


### PR DESCRIPTION
Hi～
I think https://www.kernel.org/pub/linux/kernel/v4.x/linux-4.19.tar.gz is totally depends on that alpine:latest  is using linux-4.19.0 kernel
And if further updates makes alpine switch to much more higher version kernel, maybe Dockerfile will invalid again
So, i guess maybe adding a memo to tell users the fact and offering them another optinal sentence is not a bad idea

XD